### PR TITLE
Fixed dependency check failures

### DIFF
--- a/service/controller-service/pom.xml
+++ b/service/controller-service/pom.xml
@@ -54,6 +54,7 @@
                     <cveValidForHours>${project.component.dependency-check-maven.cve-valid-for-hours}</cveValidForHours>
                     <suppressionFiles>${project.parent.basedir}/src/main/resources/dep-check/dep-check-suppressions.xml</suppressionFiles>
                     <failBuildOnCVSS>4</failBuildOnCVSS>
+                    <skipSystemScope>true</skipSystemScope>
                 </configuration>
                 <executions>
                     <execution>

--- a/service/core-service/pom.xml
+++ b/service/core-service/pom.xml
@@ -359,7 +359,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${project.component.fasterxml-jackson.version}</version>
+            <version>${project.component.fasterxml-jackson.version}.1</version>
         </dependency>
 
         <dependency>
@@ -540,7 +540,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.5</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.
@@ -589,7 +589,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <version>3.0.5</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <xmlOutputDirectory>target/site</xmlOutputDirectory>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -25,7 +25,7 @@
         <project.component.apache-poi.version>3.17</project.component.apache-poi.version>
         <!-- Test related component versions -->
         <project.component.junit.version>5.2.0</project.component.junit.version>
-        <project.component.checkstyle.version>8.8</project.component.checkstyle.version>
+        <project.component.checkstyle.version>8.22</project.component.checkstyle.version>
         <project.component.maven-checkstyle.version>3.0.0</project.component.maven-checkstyle.version>
         <project.component.maven-site-plugin.version>3.7.1</project.component.maven-site-plugin.version>
         <project.component.findbugs.version>3.0.5</project.component.findbugs.version>
@@ -33,7 +33,7 @@
         <project.component.surefire.version>2.22.0</project.component.surefire.version>
         <project.component.jacoco.version>0.8.1</project.component.jacoco.version>
         <project.component.jersey-test-framework-provider-grizzly2.version>2.27</project.component.jersey-test-framework-provider-grizzly2.version>
-        <project.component.dependency-check-maven.version>3.3.1</project.component.dependency-check-maven.version>
+        <project.component.dependency-check-maven.version>5.1.0</project.component.dependency-check-maven.version>
         <project.component.dependency-check-maven.cve-valid-for-hours>36</project.component.dependency-check-maven.cve-valid-for-hours>
         <!-- Documentation related component versions -->
         <project.component.enunciate.version>2.11.1</project.component.enunciate.version>

--- a/service/src/main/resources/dep-check/dep-check-suppressions.xml
+++ b/service/src/main/resources/dep-check/dep-check-suppressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
     <suppress>
         <notes><![CDATA[
@@ -23,6 +23,7 @@
         <gav regex="true">^com\.jcraft:jsch\.*$</gav>
         <cve>CVE-2016-5725</cve>
     </suppress>
+
     <suppress>
         <notes><![CDATA[
    File name: jsch.agentproxy.core-0.0.6.jar
@@ -109,6 +110,95 @@
         <sha1>3178f73569fd7a1e5ffc464e680f7a8cc784b85a</sha1>
         <cve>CVE-2018-1000840</cve>
     </suppress>
+
+
+    <!--
+    Suppressions for Findbugs' dependencies
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: dom4j-1.6.1.jar
+   ]]></notes>
+        <sha1>5d3ccc056b6f056dbf0dddfdf43894b9065a8f94</sha1>
+        <vulnerabilityName>CVE-2018-1000632</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: struts-core-1.3.8.jar
+   ]]></notes>
+        <sha1>66178d4a9279ebb1cd1eb79c10dc204b4199f061</sha1>
+        <vulnerabilityName>CVE-2011-5057</vulnerabilityName>
+        <vulnerabilityName>CVE-2012-0391</vulnerabilityName>
+        <vulnerabilityName>CVE-2012-0392</vulnerabilityName>
+        <vulnerabilityName>CVE-2012-0393</vulnerabilityName>
+        <vulnerabilityName>CVE-2012-0394</vulnerabilityName>
+        <vulnerabilityName>CVE-2012-0838</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-1965</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-1966</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-2115</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-2134</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-2135</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0094</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0112</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0113</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0114</vulnerabilityName>
+        <vulnerabilityName>CVE-2015-0899</vulnerabilityName>
+        <vulnerabilityName>CVE-2015-5169</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-0785</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1181</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1182</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-4003</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: struts-tiles-1.3.8.jar
+   ]]></notes>
+        <sha1>6d212f8ea5d908bc9906e669428b7694dff60785</sha1>
+        <vulnerabilityName>CVE-2012-0394</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-2115</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0114</vulnerabilityName>
+        <vulnerabilityName>CVE-2015-0899</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-0785</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1181</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1182</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: struts-taglib-1.3.8.jar
+   ]]></notes>
+        <sha1>e87e9817bdf03c2367fb5f6d5ead953db2df4c21</sha1>
+        <vulnerabilityName>CVE-2012-0394</vulnerabilityName>
+        <vulnerabilityName>CVE-2013-2115</vulnerabilityName>
+        <vulnerabilityName>CVE-2014-0114</vulnerabilityName>
+        <vulnerabilityName>CVE-2015-0899</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-0785</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1181</vulnerabilityName>
+        <vulnerabilityName>CVE-2016-1182</vulnerabilityName>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+   file name: plexus-archiver-3.4.jar
+   ]]></notes>
+        <sha1>d99cffd480e050d87d93defa605a959a15cbb611</sha1>
+        <vulnerabilityName>CVE-2018-1002200</vulnerabilityName>
+    </suppress>
+
+
+    <!-- Suppressions for maven-site-plugin
+    -->
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-compress-1.11.jar
+   ]]></notes>
+        <sha1>f43ce4c878078cbcfbb061353aa672a4c8e81443</sha1>
+        <cve>CVE-2018-11771</cve>
+        <cve>CVE-2018-1324</cve>
+    </suppress>
+
 
 </suppressions>
 


### PR DESCRIPTION
Checkstyle version to 8.22
Dependency check to 5.1.0
Jackson-databind to 2.9.9.1
Findbugs to 3.0.5
Added suppression list for findbugs dependencies since this library hasn’t been updated for almost 2 years now. And for mavens-site-plugins (similar issue)