### PR TITLE
Convert entity feature toggled-features into default behaviour

### DIFF
--- a/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseEntitiesIntents.java
+++ b/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseEntitiesIntents.java
@@ -39,9 +39,6 @@ public class DatabaseEntitiesIntents extends DatabaseAI {
 
     public List<Entity> getEntities(final UUID devid, final UUID aiid) throws DatabaseException {
         String aiidString = aiid.toString();
-        if (this.featureToggler.getStateforDev(devid, "per-bot-entities") != FeatureToggler.FeatureState.T1) {
-            aiidString = emptyAiid;
-        }
 
         try (DatabaseCall call = this.callProvider.get()) {
             call.initialise("getEntities", 2).add(devid).add(aiidString);
@@ -81,9 +78,6 @@ public class DatabaseEntitiesIntents extends DatabaseAI {
 
     public ApiEntity getEntity(final UUID devid, final String entityName, final UUID aiid) throws DatabaseException {
         String aiidString = aiid.toString();
-        if (this.featureToggler.getStateforDev(devid, "per-bot-entities") != FeatureToggler.FeatureState.T1) {
-            aiidString = emptyAiid;
-        }
 
         try (DatabaseTransaction transaction = this.transactionProvider.get()) {
             try {
@@ -147,9 +141,6 @@ public class DatabaseEntitiesIntents extends DatabaseAI {
     public int getEntityValuesCountForDevExcludingEntity(final UUID devId, final String entityName, final UUID aiid)
             throws DatabaseException {
         String aiidString = aiid.toString();
-        if (this.featureToggler.getStateforDev(devId, "per-bot-entities") != FeatureToggler.FeatureState.T1) {
-            aiidString = emptyAiid;
-        }
 
         try (DatabaseCall call = this.callProvider.get()) {
             call.initialise("getEntityValuesCountForDevExcludingEntity", 3)
@@ -247,10 +238,6 @@ public class DatabaseEntitiesIntents extends DatabaseAI {
         }
 
         String aiidString = aiid.toString();
-        if (this.featureToggler.getStateforDev(devid, "per-bot-entities") != FeatureToggler.FeatureState.T1) {
-            aiidString = emptyAiid;
-        }
-
         try {
             // add or update the entity
             transaction.getDatabaseCall().initialise("addUpdateEntity", 5)
@@ -310,10 +297,6 @@ public class DatabaseEntitiesIntents extends DatabaseAI {
     public boolean deleteEntityByName(final UUID devid, final UUID aiid, final String name,
                                       DatabaseTransaction transaction) throws DatabaseException {
         String aiidString = aiid.toString();
-        if (this.featureToggler.getStateforDev(devid, "per-bot-entities") != FeatureToggler.FeatureState.T1) {
-            aiidString = emptyAiid;
-        }
-
         boolean createTrans = transaction == null;
         if (createTrans) {
             transaction = this.transactionProvider.get();

--- a/service/core-service/src/main/java/com/hutoma/api/logic/EntityLogic.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/EntityLogic.java
@@ -180,13 +180,8 @@ public class EntityLogic {
             Set<String> referreingAis = new HashSet<>();
             List<ApiIntent> allIntents = this.database.getAllIntents(devid);
             for (ApiIntent intent : allIntents) {
-                if (featureToggler.getStateForAiid(
-                        devid,
-                        aiid,
-                        "per-bot-entities") == FeatureToggler.FeatureState.T1) {
-                    if (!intent.getAiid().equals(aiid)) {
-                        continue;
-                    }
+                if (!intent.getAiid().equals(aiid)) {
+                    continue;
                 }
                 if (intent.getVariables() != null && !intent.getVariables().isEmpty()) {
                     for (IntentVariable variable : intent.getVariables()) {

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
@@ -405,8 +405,6 @@ public class IntentProcessor {
         // This function is called with a list of memory variables - that will either be all entities linked
         // to the current intent, or a singleton if we've previously been prompted for an entity, so filter to that
         HashMap<String, List<String>> localEntityCandidateMatches = new HashMap<>();
-        // Keep a mapping of entity names to entity labels for this intent, for later
-        //HashMap<String, String> localEntityNameLabelMap = new HashMap<>();
 
         // Loop through the supplied variables only (to handle the case of this being a prompted run)
         for (MemoryVariable variable : memoryVariables) {
@@ -423,14 +421,11 @@ public class IntentProcessor {
                         newEntities.add(variable.getName());
                         localEntityCandidateMatches.put(candidate.getKey(), newEntities);
                     }
-                    //localEntityNameLabelMap.put(variable.getName(), variable.getLabel());
                 }
             }
         }
 
         // At this point we have localEntityCandidateMatches - Map of strings to List<entity names> (in scope only)
-        // And localEntityNameLabelMap - map of entityName to entityLabel (in scope only)
-
         // If there are any candidateValues remaining with only one possible match, use that one
         for (Map.Entry<String, List<String>> candidate : localEntityCandidateMatches.entrySet()) {
             if (candidate.getValue().size() == 1) {

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
@@ -398,55 +398,49 @@ public class IntentProcessor {
 
         // we have a potential list of entities from the above call. need also to consider the candidate
         // entity values from chat entity value handler
-        if (featureToggler.getStateForAiid(
-                chatInfo.getDevId(),
-                chatInfo.getAiid(),
-                "entity-value-replacement") == FeatureToggler.FeatureState.T1) {
-            logger.logInfo("IntentProcessor",
-                    "Checking for entity value matching for intent "
-                            + intent.getIntentName());
+        logger.logInfo("IntentProcessor",
+                String.format("Checking for entity value matching for intent %s", intent.getIntentName()));
 
-            // We need to filter the relevant candidates and then count how many we have left
-            // This function is called with a list of memory variables - that will either be all entities linked
-            // to the current intent, or a singleton if we've previously been prompted for an entity, so filter to that
-            HashMap<String, List<String>> localEntityCandidateMatches = new HashMap<>();
-            // Keep a mapping of entity names to entity labels for this intent, for later
-            //HashMap<String, String> localEntityNameLabelMap = new HashMap<>();
+        // We need to filter the relevant candidates and then count how many we have left
+        // This function is called with a list of memory variables - that will either be all entities linked
+        // to the current intent, or a singleton if we've previously been prompted for an entity, so filter to that
+        HashMap<String, List<String>> localEntityCandidateMatches = new HashMap<>();
+        // Keep a mapping of entity names to entity labels for this intent, for later
+        //HashMap<String, String> localEntityNameLabelMap = new HashMap<>();
 
-            // Loop through the supplied variables only (to handle the case of this being a prompted run)
-            for (MemoryVariable variable : memoryVariables) {
-                // Loop through the list of values to entity names from ER
-                for (Map.Entry<String, List<String>> candidate :
-                        chatResult.getChatState().getCandidateValues().entrySet()) {
-                    // If the entity name is in the list of entity names from the candidate matches then...
-                    if (candidate.getValue().contains(variable.getName())) {
-                        // ...we need to consider this value
-                        if (localEntityCandidateMatches.containsKey(candidate.getKey())) {
-                            localEntityCandidateMatches.get(candidate.getKey()).add(variable.getName());
-                        } else {
-                            List<String> newEntities = new ArrayList<String>();
-                            newEntities.add(variable.getName());
-                            localEntityCandidateMatches.put(candidate.getKey(), newEntities);
-                        }
-                        //localEntityNameLabelMap.put(variable.getName(), variable.getLabel());
+        // Loop through the supplied variables only (to handle the case of this being a prompted run)
+        for (MemoryVariable variable : memoryVariables) {
+            // Loop through the list of values to entity names from ER
+            for (Map.Entry<String, List<String>> candidate :
+                    chatResult.getChatState().getCandidateValues().entrySet()) {
+                // If the entity name is in the list of entity names from the candidate matches then...
+                if (candidate.getValue().contains(variable.getName())) {
+                    // ...we need to consider this value
+                    if (localEntityCandidateMatches.containsKey(candidate.getKey())) {
+                        localEntityCandidateMatches.get(candidate.getKey()).add(variable.getName());
+                    } else {
+                        List<String> newEntities = new ArrayList<String>();
+                        newEntities.add(variable.getName());
+                        localEntityCandidateMatches.put(candidate.getKey(), newEntities);
                     }
+                    //localEntityNameLabelMap.put(variable.getName(), variable.getLabel());
                 }
             }
+        }
 
-            // At this point we have localEntityCandidateMatches - Map of strings to List<entity names> (in scope only)
-            // And localEntityNameLabelMap - map of entityName to entityLabel (in scope only)
+        // At this point we have localEntityCandidateMatches - Map of strings to List<entity names> (in scope only)
+        // And localEntityNameLabelMap - map of entityName to entityLabel (in scope only)
 
-            // If there are any candidateValues remaining with only one possible match, use that one
-            for (Map.Entry<String, List<String>> candidate : localEntityCandidateMatches.entrySet()) {
-                if (candidate.getValue().size() == 1) {
-                    String entityName = candidate.getValue().get(0);
-                    String entityValue = candidate.getKey();
-                    // Update the entity list
-                    entities.add(new Pair<>(entityName, entityValue));
+        // If there are any candidateValues remaining with only one possible match, use that one
+        for (Map.Entry<String, List<String>> candidate : localEntityCandidateMatches.entrySet()) {
+            if (candidate.getValue().size() == 1) {
+                String entityName = candidate.getValue().get(0);
+                String entityValue = candidate.getKey();
+                // Update the entity list
+                entities.add(new Pair<>(entityName, entityValue));
 
-                    logger.logInfo("IntentProcessor",
-                            String.format("Added entity value %s from entity value matching", entityValue));
-                }
+                logger.logInfo("IntentProcessor",
+                        String.format("Added entity value %s from entity value matching", entityValue));
             }
         }
 

--- a/service/core-service/src/main/java/com/hutoma/api/memory/ExternalEntityRecognizer.java
+++ b/service/core-service/src/main/java/com/hutoma/api/memory/ExternalEntityRecognizer.java
@@ -51,16 +51,7 @@ public class ExternalEntityRecognizer implements IEntityRecognizer {
         final SupportedLanguage language = chatInfo.getAiIdentity().getLanguage();
         List<Pair<String, String>> result = new ArrayList<>();
 
-        // Protect SimpleEntityRecognizer call behind a toggle
-        if (featureToggler.getStateForAiid(chatInfo.getDevId(),
-                chatInfo.getAiid(),
-                "no-simple-er") != FeatureToggler.FeatureState.T1) {
-            // Call the simple regex entity recognizer for custom entities
-            result.addAll(SimpleEntityRecognizer.regexFindEntities(chatLine, customEntities));
-        }
-
         // Call the external entity recognizer for system entities
-
         List<RecognizedEntity> systemEntities = this.service.getEntities(chatLine, language);
         for (RecognizedEntity re : systemEntities) {
             if (!re.getCategory().equalsIgnoreCase(NUMBER_ENTITY_NAME)) {

--- a/service/core-service/src/test/java/com/hutoma/api/memory/TestSimpleEntityRecognizer.java
+++ b/service/core-service/src/test/java/com/hutoma/api/memory/TestSimpleEntityRecognizer.java
@@ -2,10 +2,12 @@ package com.hutoma.api.memory;
 
 import com.hutoma.api.common.SupportedLanguage;
 import com.hutoma.api.containers.sub.ChatRequestInfo;
+import com.hutoma.api.containers.sub.RecognizedEntity;
 import com.hutoma.api.logging.ILogger;
 import com.hutoma.api.common.Pair;
 import com.hutoma.api.containers.sub.MemoryVariable;
 
+import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,17 +34,17 @@ public class TestSimpleEntityRecognizer {
 
     @Test
     public void testRecognizeOneEntity() {
-        recognizeOneEntity(recognizer);
+        recognizeOneEntity(recognizer, "NAME", "VALUE");
     }
 
     @Test
     public void testRecognizeMultipleEntities() {
-        recognizeMultipleEntities(recognizer);
+        final String[] varNames = {"var1", "var2"};
+        final String[] varValues = {"value1", "value2"};
+        recognizeMultipleEntities(recognizer, varNames, varValues);
     }
 
-    public static void recognizeOneEntity(final IEntityRecognizer recognizer) {
-        final String variableName = "NAME";
-        final String variableValue = "VARIABLE";
+    public static void recognizeOneEntity(final IEntityRecognizer recognizer, final String variableName, final String variableValue) {
         List<MemoryVariable> l = new ArrayList<MemoryVariable>() {{
             this.add(new MemoryVariable(variableName, Arrays.asList(variableValue, "another value")));
         }};
@@ -56,14 +59,12 @@ public class TestSimpleEntityRecognizer {
         Assert.assertEquals(variableValue, r.get(0).getB());
     }
 
-    public static void recognizeMultipleEntities(final IEntityRecognizer recognizer) {
-        final String[] varNames = {"var1", "var2"};
-        final String[] varValues = {"value1", "value2"};
-        List<MemoryVariable> l = new ArrayList<MemoryVariable>() {{
-            this.add(new MemoryVariable(varNames[0], Arrays.asList("A", varValues[0], "B")));
-            this.add(new MemoryVariable(varNames[1], Arrays.asList(varValues[1], "K")));
-            this.add(new MemoryVariable("some other", Arrays.asList("X", "Y")));
-        }};
+    public static void recognizeMultipleEntities(final IEntityRecognizer recognizer, final String[] varNames, final String[] varValues) {
+        List<MemoryVariable> l = new ArrayList<>();
+        for (int i = 0; i < varNames.length; i++) {
+            l.add(new MemoryVariable(varNames[i], Arrays.asList("A", varValues[i], "B")));
+        }
+        l.add(new MemoryVariable("some other", Arrays.asList("X", "Y")));
 
         ChatRequestInfo fakeChatInfo = mock(ChatRequestInfo.class, Mockito.RETURNS_DEEP_STUBS);
         when(fakeChatInfo.getQuestion()).thenReturn(


### PR DESCRIPTION
Turn prevoiously feature toggled features related to entity handling into default behaviour as these have been set for all users/bots for a few months now. These are:
- entity-value-replacement
- regex-entity
- per-bot-entities
- no-simple-er