### PR TITLE
Replace Apache Commons' StringUtils.isEmpty.

### DIFF
--- a/service/common-lib/src/main/java/com/hutoma/api/common/Tools.java
+++ b/service/common-lib/src/main/java/com/hutoma/api/common/Tools.java
@@ -151,4 +151,8 @@ public class Tools {
     public static double toOneDecimalPlace(double input) {
         return Math.round(input * 10.0d) / 10.0d;
     }
+
+    public static boolean isEmpty(String str) {
+        return str == null || str.length() == 0;
+    }
 }

--- a/service/common-lib/src/main/java/com/hutoma/api/containers/sub/AiIdentity.java
+++ b/service/common-lib/src/main/java/com/hutoma/api/containers/sub/AiIdentity.java
@@ -1,6 +1,7 @@
 package com.hutoma.api.containers.sub;
 
 import com.hutoma.api.common.SupportedLanguage;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.containers.ServiceIdentity;
 import org.apache.commons.lang.StringUtils;
 
@@ -44,7 +45,7 @@ public class AiIdentity {
     }
 
     public String getServerVersion() {
-        if (StringUtils.isEmpty(this.serverVersion)) {
+        if (Tools.isEmpty(this.serverVersion)) {
             return ServiceIdentity.DEFAULT_VERSION;
         }
         return this.serverVersion;

--- a/service/controller-service/src/main/java/com/hutoma/api/validation/ControllerPostFilter.java
+++ b/service/controller-service/src/main/java/com/hutoma/api/validation/ControllerPostFilter.java
@@ -111,7 +111,7 @@ public class ControllerPostFilter extends ControllerParameterFilter implements C
                 if (aiStatus.getAiEngineLanguage() == null) {
                     aiStatus.setAiEngineLanguage(SupportedLanguage.EN);
                 }
-                if (StringUtils.isEmpty(aiStatus.getAiEngineVersion())) {
+                if (Tools.isEmpty(aiStatus.getAiEngineVersion())) {
                     aiStatus.setAiEngineVersion(ServiceIdentity.DEFAULT_VERSION);
                 }
                 request.setProperty(ControllerParameter.AiStatusJson.toString(), aiStatus);
@@ -131,7 +131,7 @@ public class ControllerPostFilter extends ControllerParameterFilter implements C
                 if (serverRegistration.getLanguage() == null) {
                     serverRegistration.setLanguage(SupportedLanguage.EN);
                 }
-                if (StringUtils.isEmpty(serverRegistration.getVersion())) {
+                if (Tools.isEmpty(serverRegistration.getVersion())) {
                     serverRegistration.setVersion(ServiceIdentity.DEFAULT_VERSION);
                 }
                 request.setProperty(ControllerParameter.ServerRegistration.toString(), serverRegistration);
@@ -145,7 +145,7 @@ public class ControllerPostFilter extends ControllerParameterFilter implements C
                 if (serverAffinity.getLanguage() == null) {
                     serverAffinity.setLanguage(SupportedLanguage.EN);
                 }
-                if (StringUtils.isEmpty(serverAffinity.getVersion())) {
+                if (Tools.isEmpty(serverAffinity.getVersion())) {
                     serverAffinity.setVersion(ServiceIdentity.DEFAULT_VERSION);
                 }
                 request.setProperty(ControllerParameter.ServerAffinity.toString(), serverAffinity);

--- a/service/controller-service/src/main/java/com/hutoma/api/validation/ControllerQueryFilter.java
+++ b/service/controller-service/src/main/java/com/hutoma/api/validation/ControllerQueryFilter.java
@@ -131,7 +131,7 @@ public class ControllerQueryFilter extends ControllerParameterFilter implements 
     }
 
     private static SupportedLanguage validateLanguage(final String language) throws ParameterValidationException {
-        if (StringUtils.isEmpty(language)) {
+        if (Tools.isEmpty(language)) {
             return SupportedLanguage.EN;
         }
         Optional<SupportedLanguage> value = Arrays.stream(SupportedLanguage.values())
@@ -143,7 +143,7 @@ public class ControllerQueryFilter extends ControllerParameterFilter implements 
     }
 
     private static String validateServerVersion(final String version) throws ParameterValidationException {
-        if (StringUtils.isEmpty(version)) {
+        if (Tools.isEmpty(version)) {
             return ServiceIdentity.DEFAULT_VERSION;
         }
         if (version.length() > 10) {

--- a/service/core-service/src/main/java/com/hutoma/api/connectors/chat/ChatBackendConnector.java
+++ b/service/core-service/src/main/java/com/hutoma/api/connectors/chat/ChatBackendConnector.java
@@ -88,7 +88,7 @@ public abstract class ChatBackendConnector {
         for (AiIdentity ai : ais) {
             UUID aiid = ai.getAiid();
             ApiServerEndpointMulti.ServerEndpointResponse endpoint = endpointMap.get(aiid);
-            if ((endpoint == null) || (StringUtils.isEmpty(endpoint.getServerUrl()))) {
+            if (endpoint == null || Tools.isEmpty(endpoint.getServerUrl())) {
                 throw new NoServerAvailableException(String.format("No server available for %s for %s on %s",
                         aiid.toString(), RequestFor.Chat.toString(), this.getServerType().value()));
             }

--- a/service/core-service/src/main/java/com/hutoma/api/connectors/chat/ChatBackendRequester.java
+++ b/service/core-service/src/main/java/com/hutoma/api/connectors/chat/ChatBackendRequester.java
@@ -116,7 +116,7 @@ public class ChatBackendRequester implements Callable<InvocationResult> {
                     // make sure that we got a valid endpoint back from the controller
                     serverEndpointResponse = endpointMap.get(this.ai.getAiid());
                     if ((serverEndpointResponse == null)
-                            || StringUtils.isEmpty(serverEndpointResponse.getServerIdentifier())) {
+                            || Tools.isEmpty(serverEndpointResponse.getServerIdentifier())) {
 
                         // if not, throw a descriptive exception
                         throw new NoServerAvailableException.ServiceTooBusyException(alreadyTried);

--- a/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseAI.java
+++ b/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseAI.java
@@ -4,6 +4,7 @@ import com.google.gson.reflect.TypeToken;
 import com.hutoma.api.common.JsonSerializer;
 import com.hutoma.api.common.Pair;
 import com.hutoma.api.common.SupportedLanguage;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.BackendStatus;
 import com.hutoma.api.containers.*;
 import com.hutoma.api.containers.sub.*;
@@ -417,7 +418,7 @@ public class DatabaseAI extends Database {
         try {
             ApiAi ai = getAI(devId, aiid, serializer, transaction);
             if (ai != null) {
-                String engineVersion = StringUtils.isEmpty(overridenEngineVersion)
+                String engineVersion = Tools.isEmpty(overridenEngineVersion)
                         ? ai.getEngineVersion() : overridenEngineVersion;
 
                 Locale locale = ai.getLanguage();
@@ -869,7 +870,7 @@ public class DatabaseAI extends Database {
             confidenceThreshold = ai.getConfidence();
         }
         String contextJson = rs.getString("context");
-        ChatContext context = StringUtils.isEmpty(contextJson)
+        ChatContext context = Tools.isEmpty(contextJson)
                 ? new ChatContext()
                 : (ChatContext) jsonSerializer.deserialize(contextJson, ChatContext.class);
         ChatState chatState = new ChatState(
@@ -886,7 +887,7 @@ public class DatabaseAI extends Database {
         chatState.setChatId(UUID.fromString(rs.getString("chat_id")));
         Type memoryIntentListType = new TypeToken<List<MemoryIntent>>() {
         }.getType();
-        List<MemoryIntent> currentIntents = StringUtils.isEmpty(intentsJson)
+        List<MemoryIntent> currentIntents = Tools.isEmpty(intentsJson)
                 ? new ArrayList<>()
                 : jsonSerializer.deserializeList(intentsJson, memoryIntentListType);
         chatState.setCurrentIntents(currentIntents);
@@ -896,7 +897,7 @@ public class DatabaseAI extends Database {
         String webhookSessionsJson = rs.getString("webhook_sessions");
         Type webhookSessionsListType = new TypeToken<List<WebHookSession>>() {
         }.getType();
-        List<WebHookSession> webhookSessions = StringUtils.isEmpty(webhookSessionsJson)
+        List<WebHookSession> webhookSessions = Tools.isEmpty(webhookSessionsJson)
                 ? new ArrayList<>()
                 : jsonSerializer.deserializeList(webhookSessionsJson, webhookSessionsListType);
         chatState.setWebhookSessions(webhookSessions);

--- a/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseFeatures.java
+++ b/service/core-service/src/main/java/com/hutoma/api/connectors/db/DatabaseFeatures.java
@@ -1,5 +1,6 @@
 package com.hutoma.api.connectors.db;
 
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.logging.ILogger;
 import org.apache.commons.lang.StringUtils;
 
@@ -28,9 +29,9 @@ public class DatabaseFeatures extends Database {
                     .executeQuery();
             while (rs.next()) {
                 String value = rs.getString("devid");
-                UUID devId = StringUtils.isEmpty(value) ? null : UUID.fromString(value.trim());
+                UUID devId = Tools.isEmpty(value) ? null : UUID.fromString(value.trim());
                 value = rs.getString("aiid");
-                UUID aiid = StringUtils.isEmpty(value) ? null : UUID.fromString(value.trim());
+                UUID aiid = Tools.isEmpty(value) ? null : UUID.fromString(value.trim());
                 DatabaseFeature feature = new DatabaseFeature(
                         devId,
                         aiid,

--- a/service/core-service/src/main/java/com/hutoma/api/containers/facebook/FacebookMessageNode.java
+++ b/service/core-service/src/main/java/com/hutoma/api/containers/facebook/FacebookMessageNode.java
@@ -1,6 +1,7 @@
 package com.hutoma.api.containers.facebook;
 
 import com.google.gson.annotations.SerializedName;
+import com.hutoma.api.common.Tools;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.List;
@@ -77,6 +78,6 @@ public class FacebookMessageNode extends FacebookRichContentAttachment {
     }
 
     public boolean hasText() {
-        return !StringUtils.isEmpty(this.text);
+        return !Tools.isEmpty(this.text);
     }
 }

--- a/service/core-service/src/main/java/com/hutoma/api/endpoints/AIEndpoint.java
+++ b/service/core-service/src/main/java/com/hutoma/api/endpoints/AIEndpoint.java
@@ -5,6 +5,7 @@ import com.hutoma.api.access.RateLimit;
 import com.hutoma.api.access.Role;
 import com.hutoma.api.access.Secured;
 import com.hutoma.api.common.JsonSerializer;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.containers.*;
 import com.hutoma.api.containers.sub.AiBot;
 import com.hutoma.api.containers.sub.BotStructure;
@@ -296,7 +297,7 @@ public class AIEndpoint {
                 voice,
                 ParameterFilter.getLocale(requestContext),
                 ParameterFilter.getTimezone(requestContext),
-                StringUtils.isEmpty(defaultResponses)
+                Tools.isEmpty(defaultResponses)
                         ? new ArrayList<>()
                         : this.serializer.deserializeListAutoDetect(defaultResponses),
                 passthroughUrl);

--- a/service/core-service/src/main/java/com/hutoma/api/logic/AIIntegrationLogic.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/AIIntegrationLogic.java
@@ -2,6 +2,7 @@ package com.hutoma.api.logic;
 
 import com.hutoma.api.common.Config;
 import com.hutoma.api.common.JsonSerializer;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.FacebookConnector;
 import com.hutoma.api.connectors.FacebookException;
 import com.hutoma.api.connectors.db.DatabaseException;
@@ -165,7 +166,7 @@ public class AIIntegrationLogic {
                         record.getData(), FacebookIntegrationMetadata.class);
 
                 // do we have a token?
-                boolean tokenPresent = !StringUtils.isEmpty(metadata.getAccessToken());
+                boolean tokenPresent = !Tools.isEmpty(metadata.getAccessToken());
                 // is it expired?
                 boolean tokenValid = metadata.getAccessTokenExpiry().isAfter(DateTime.now());
 
@@ -184,8 +185,8 @@ public class AIIntegrationLogic {
 
                     // if we have no page token then get a list of available pages
                     // that the user can select
-                    if (StringUtils.isEmpty(record.getIntegrationResource())
-                            || StringUtils.isEmpty(metadata.getPageToken())) {
+                    if (Tools.isEmpty(record.getIntegrationResource())
+                            || Tools.isEmpty(metadata.getPageToken())) {
                         // get nodes and convert to an id->name map
                         Map<String, String> pages = getListOfUserPages(metadata).stream().collect(
                                 Collectors.toMap(FacebookNode::getId, FacebookNode::getName));
@@ -347,7 +348,7 @@ public class AIIntegrationLogic {
                 FacebookIntegrationMetadata metadata = (FacebookIntegrationMetadata) this.serializer.deserialize(
                         record.getData(), FacebookIntegrationMetadata.class);
 
-                if (!StringUtils.isEmpty(action)) {
+                if (!Tools.isEmpty(action)) {
                     switch (action) {
                         case "page":
                             return pageSelect(logMap, devid, aiid, record, metadata, pageId);
@@ -534,7 +535,7 @@ public class AIIntegrationLogic {
                                            final FacebookIntegrationMetadata metadata) {
         try {
             // if we have a token, use it to unsubscribe
-            if ((record != null) && (metadata != null) && !StringUtils.isEmpty(metadata.getPageToken())) {
+            if (record != null && metadata != null && !Tools.isEmpty(metadata.getPageToken())) {
                 this.facebookConnector.pageUnsubscribe(record.getIntegrationResource(), metadata.getPageToken());
                 logMap.add("unsubscribe", "succeeded");
             } else {

--- a/service/core-service/src/main/java/com/hutoma/api/logic/AILogic.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/AILogic.java
@@ -136,7 +136,7 @@ public class AILogic {
             throw new IllegalArgumentException("transaction");
         }
 
-        if (StringUtils.isEmpty(handoverMessage) && errorThresholdHandover >= 0) {
+        if (Tools.isEmpty(handoverMessage) && errorThresholdHandover >= 0) {
             return ApiError.getBadRequest("Must specify a handover message when specifying a handover threshold");
         }
 
@@ -971,7 +971,7 @@ public class AILogic {
             LogMap logMap = LogMap.map("AIID", aiid);
             ApiAi ai;
 
-            if (StringUtils.isEmpty(engineVersion)) {
+            if (Tools.isEmpty(engineVersion)) {
                 ai = transaction == null
                         ? this.databaseAi.getAIWithStatus(devid, aiid, this.jsonSerializer)
                         : this.databaseAi.getAIWithStatus(devid, aiid, this.jsonSerializer, transaction);
@@ -1073,7 +1073,7 @@ public class AILogic {
                                 .put("Message", result.getStatus().getInfo()));
                 // The info from an error on CreateAI should already be customer-friendly, so just
                 // pass it back to the user if there is already one.
-                throw new BotImportException(org.apache.commons.lang.StringUtils.isEmpty(result.getStatus().getInfo())
+                throw new BotImportException(Tools.isEmpty(result.getStatus().getInfo())
                         ? IMPORT_GENERIC_ERROR
                         : result.getStatus().getInfo());
             }

--- a/service/core-service/src/main/java/com/hutoma/api/logic/ChatLogic.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/ChatLogic.java
@@ -350,8 +350,8 @@ public class ChatLogic {
             if ((variables != null) && (!variables.isEmpty())) {
                 this.chatState = this.chatStateHandler.getState(devId, aiid, chatUuid);
                 for (Map.Entry<String, String> v : variables.entrySet()) {
-                    if (StringUtils.isEmpty(v.getKey())
-                            || (StringUtils.isEmpty(v.getValue()))) {
+                    if (Tools.isEmpty(v.getKey())
+                            || Tools.isEmpty(v.getValue())) {
                         return ApiError.getBadRequest("Invalid variable");
                     } else {
                         this.chatState.getChatContext().setValue(v.getKey(), v.getValue(),

--- a/service/core-service/src/main/java/com/hutoma/api/logic/FacebookChatHandler.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/FacebookChatHandler.java
@@ -136,7 +136,7 @@ public class FacebookChatHandler implements Callable {
             // the Facebook user who sent the message (we need to respond to this user)
             String messageOriginatorId = this.messaging.getSender();
 
-            if (StringUtils.isEmpty(userQuery)) {
+            if (Tools.isEmpty(userQuery)) {
                 this.logger.logDebug(LOGFROM, "facebook webhook with no usable payload", logMap);
                 return null;
             }
@@ -173,7 +173,7 @@ public class FacebookChatHandler implements Callable {
                     integrationRecord.getData(), FacebookIntegrationMetadata.class);
 
             // have we got a valid page token? bail if not
-            if ((metadata == null) || StringUtils.isEmpty(metadata.getPageToken())) {
+            if ((metadata == null) || Tools.isEmpty(metadata.getPageToken())) {
                 this.logger.logError(LOGFROM,
                         "bad facebook integration config. cannot get page token",
                         logMap);
@@ -491,7 +491,7 @@ public class FacebookChatHandler implements Callable {
                                        final List<FacebookResponseSegment> responseList, final String intentPrompted) {
 
         // is this an intent prompt?
-        if (StringUtils.isEmpty(intentPrompted)) {
+        if (Tools.isEmpty(intentPrompted)) {
             return false;
         }
         // load the memory variable

--- a/service/core-service/src/main/java/com/hutoma/api/logic/TrainingLogic.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/TrainingLogic.java
@@ -1,10 +1,6 @@
 package com.hutoma.api.logic;
 
-import com.hutoma.api.common.Config;
-import com.hutoma.api.common.FeatureToggler;
-import com.hutoma.api.common.HTMLExtractor;
-import com.hutoma.api.common.JsonSerializer;
-import com.hutoma.api.common.SupportedLanguage;
+import com.hutoma.api.common.*;
 import com.hutoma.api.connectors.BackendServerType;
 import com.hutoma.api.connectors.BackendStatus;
 import com.hutoma.api.connectors.aiservices.AIServices;
@@ -344,7 +340,7 @@ public class TrainingLogic {
         LogMap logMap = LogMap.map("AIID", aiid);
         try {
 
-            ApiAi ai = StringUtils.isEmpty(overridenEngineVersion)
+            ApiAi ai = Tools.isEmpty(overridenEngineVersion)
                     ? this.databaseAi.getAIWithStatus(devid, aiid, this.jsonSerializer)
                     : this.databaseAi.getAIWithStatusForEngineVersion(devid, aiid, overridenEngineVersion,
                     this.jsonSerializer);
@@ -352,7 +348,7 @@ public class TrainingLogic {
                 this.logger.logUserTraceEvent(LOGFROM, "UpdateTraining - AI not found", devidString, logMap);
                 return ApiError.getNotFound();
             }
-            String engineVersion = StringUtils.isEmpty(overridenEngineVersion)
+            String engineVersion = Tools.isEmpty(overridenEngineVersion)
                     ? ai.getEngineVersion() : overridenEngineVersion;
             logMap.add("EngineVersion", engineVersion);
             if (!allowRetrainReadonlyBot && ai.isReadOnly()) {

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatDefaultHandler.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatDefaultHandler.java
@@ -1,5 +1,6 @@
 package com.hutoma.api.logic.chat;
 
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.AiStrings;
 import com.hutoma.api.containers.sub.ChatHandoverTarget;
 import com.hutoma.api.containers.sub.ChatRequestInfo;
@@ -53,7 +54,7 @@ public class ChatDefaultHandler implements IChatHandler {
             if (state.getBadAnswersCount() >= state.getAi().getErrorThresholdHandover()) {
                 state.setChatTarget(ChatHandoverTarget.Other);
                 state.setBadAnswersCount(0);
-                if (!StringUtils.isEmpty(state.getAi().getHandoverMessage())) {
+                if (!Tools.isEmpty(state.getAi().getHandoverMessage())) {
                     currentResult.setAnswer(state.getAi().getHandoverMessage());
                 } else {
                     currentResult.setAnswer(null);

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatEmbHandler.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatEmbHandler.java
@@ -1,6 +1,7 @@
 package com.hutoma.api.logic.chat;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.BackendServerType;
 import com.hutoma.api.connectors.ServerConnector;
 import com.hutoma.api.connectors.WebHooks;
@@ -75,7 +76,7 @@ public class ChatEmbHandler extends ChatGenericBackend implements IChatHandler {
                     currentResult.setIntents(result.getIntents());
                     currentResult.setWebHookResponse(result.getWebhookResponse());
                     currentResult.setScore(result.getScore());
-                    if (!StringUtils.isEmpty(result.getPromptForIntentVariable())) {
+                    if (!Tools.isEmpty(result.getPromptForIntentVariable())) {
                         currentResult.setPromptForIntentVariable(result.getPromptForIntentVariable());
                     }
                 } else {

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatPassthroughHandler.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/ChatPassthroughHandler.java
@@ -55,7 +55,7 @@ public class ChatPassthroughHandler implements IChatHandler {
 
         String passthrough = this.chatServices.getAIPassthroughUrl(requestInfo.getDevId(), requestInfo.getAiid());
 
-        if (!StringUtils.isEmpty(passthrough)) {
+        if (!Tools.isEmpty(passthrough)) {
             // Add telemetry for the request
             final UUID devId = requestInfo.getDevId();
             final String devIdString = devId.toString();

--- a/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
+++ b/service/core-service/src/main/java/com/hutoma/api/logic/chat/IntentProcessor.java
@@ -3,6 +3,7 @@ package com.hutoma.api.logic.chat;
 import com.hutoma.api.common.Config;
 import com.hutoma.api.common.FeatureToggler;
 import com.hutoma.api.common.Pair;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.WebHooks;
 import com.hutoma.api.connectors.db.DatabaseException;
 import com.hutoma.api.containers.ApiIntent;
@@ -91,7 +92,7 @@ public class IntentProcessor {
         // Exit if we can't execute intent
         ApiIntent intent = this.intentHandler.getIntent(aiidForMemoryIntents, currentIntent.getName());
         if (!canExecuteIntent(intent, chatResult)) {
-            if (StringUtils.isEmpty(intent.getConditionsFallthroughMessage())) {
+            if (Tools.isEmpty(intent.getConditionsFallthroughMessage())) {
                 return false;
             } else {
                 chatResult.setScore(chatContext.getIntentScore());
@@ -745,7 +746,7 @@ public class IntentProcessor {
                 chatResult.setWebHookResponse(response);
 
                 // log and set the text if there was any
-                if (!StringUtils.isEmpty(response.getText())) {
+                if (!Tools.isEmpty(response.getText())) {
                     // copy the text reply
                     chatResult.setAnswer(response.getText());
                     // and copy the whole response to include any rich content

--- a/service/core-service/src/test/java/com/hutoma/api/tests/service/TestServiceAi.java
+++ b/service/core-service/src/test/java/com/hutoma/api/tests/service/TestServiceAi.java
@@ -3,6 +3,7 @@ package com.hutoma.api.tests.service;
 import com.hutoma.api.common.JsonSerializer;
 import com.hutoma.api.common.Pair;
 import com.hutoma.api.common.TestDataHelper;
+import com.hutoma.api.common.Tools;
 import com.hutoma.api.connectors.BackendEngineStatus;
 import com.hutoma.api.connectors.BackendServerType;
 import com.hutoma.api.connectors.BackendStatus;
@@ -507,7 +508,7 @@ public class TestServiceAi extends ServiceTestBase {
                         "   }" +
                         "}",
                 description,
-                StringUtils.isEmpty(entities) ? "" : ("," + entities));
+                Tools.isEmpty(entities) ? "" : ("," + entities));
     }
 
     private ApiAi checkMaskedTrainingStatus(


### PR DESCRIPTION
For some reason, after our last maven libraries update on the 9/Jul/2019 StringUtils.isEmpty stopped checking for null, causing NPEs to occur all over the place where this was being used. This could be cuased by mismatching versions pulled in by different dependencies. Replaced that call with our own, which basically does what StirngUtils.isEmpty was supposed to be doing.